### PR TITLE
let api call limit dictate when to suspend or resume api calls operation.

### DIFF
--- a/config/graf/email_to_company.json
+++ b/config/graf/email_to_company.json
@@ -153,6 +153,10 @@
       "alias": ["condclimate"]
     },
     {
+      "name": "Contegix LLC",
+      "alias": ["contegix"]
+    },
+    {
       "name": "Flynn",
       "alias": ["flynn"]
     },

--- a/config/graf/merge_companies.json
+++ b/config/graf/merge_companies.json
@@ -165,6 +165,10 @@
       "alias": ["codeclimate"]
     },
     {
+      "name": "Contegix LLC",
+      "alias": ["contegix"]
+    },
+    {
       "name": "Flynn",
       "alias": ["flynn"]
     },

--- a/config/graf/org_to_company_mapping.json
+++ b/config/graf/org_to_company_mapping.json
@@ -137,6 +137,10 @@
       "orgs": ["codeclimate"]
     },
     {
+      "company": "Contegix LLC",
+      "orgs": ["contegix"]
+    },
+    {
       "company": "Flynn",
       "orgs": ["Flynn"]
     },


### PR DESCRIPTION
Github's api call meter doesn't seem to operate on a steady rate.  So logic being built around the advertised rate limit doesn't always work.  In order to keep up with github's dynamic rate limits, the changes made in this PR is to have the call rate regulator to be based on rate limit advertised on the github message headers, even though this approach can incur additional communication with github.com over the network. 

Also added one more company to the reference company list.
