### PR TITLE
employ miniturized version javascript library files

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,15 +10,15 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery.min.js
 //= require jquery_ujs
 //= require jquery.ui.all
-//= require jquery.flot
-//= require jquery.flot.pie
-//= require jquery.flot.time
-//= require jquery.flot.navigate
-//= require jquery.flot.resize
-//= require jquery.flot.stack
+//= require jquery.flot.min.js
+//= require jquery.flot.pie.min.js
+//= require jquery.flot.time.min.js
+//= require jquery.flot.navigate.min.js
+//= require jquery.flot.resize.min.js
+//= require jquery.flot.stack.min.js
 //= require jquery.flot.selection.js
 //= require turbolinks
 //= require jquery.multiselect


### PR DESCRIPTION
Currently thirdparty Java Script library files the application depends on are in the fully expanded form, along with comments embedded in the files.  Long variable names and embedded comments are perfectly suited for debugging, tracing and understanding of how the code works. They add unnecessary burden to transmission over the internet and cause long response time.  This PR aims at switching to the miniaturized counter part of these library files.
