### PR TITLE
fixed wrapped page buttons on the upper right corner of a page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,7 +25,7 @@ div.banner {
   font-weight:normal;
   float:left;
   font-size: 24px;
-  background-color: #ffffff;
+  background-color: #fff;
 }
 
 div.inner_banner {
@@ -35,7 +35,7 @@ div.inner_banner {
   font-weight:normal;
   float:left;
   font-size: 24px;
-  background-color: #ffffff;
+  background-color: #fff;
 }
 
 div.header-links {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
 </head>
 <meta charset="UTF-8">
 <body>
-<div id='content' style='position:relative;'>
+<div id='content' >
 <div class='page' style='height:100%;'>
 <div class="banner">
   <div style='display:inline;height:90px;width:960px;'>
@@ -27,16 +27,16 @@
           <img src="http://cloudfoundry.org/images/logo_org.png" alt="Community Analytics for the Cloud Foundry Foundation." style='height:80px;width:120px;'>
        </a>
       </td>
-      <td style='width:100%;'>
-        <span style='font-size: 23px;font-weight:500;line-height:30px;'> Community Analytics: Cloud Foundry Foundation</span>
+      <td style='width:570px;padding-bottom: 30px;'>
+        <span style='font-size: 22px;font-weight:500;line-height:30px;'> Community Analytics: Cloud Foundry Foundation </span>
     <% else %>
       <td style='float:left;padding: 4px 10px;'>
         <a href="https://www.docker.com/">
           <img src="https://d3oypxn00j2a10.cloudfront.net/0.12.6/img/homepage/docker-whale-home-logo-@2x.png?e2946566d408" alt="Community Analytics for the Docker Community." style='height:80px;width:120px;'>
         </a>
       </td>
-      <td style='width:100%;'>
-        <span style='font-size: 23px;font-weight:500;line-height:30px;'> Community Analytics: Docker </span>
+      <td style='width:570px;padding-bottom: 30px;'>
+        <span style='font-size: 22px;font-weight:500;line-height:30px;'> Community Analytics: Docker </span>
   <% end %>
         <span>
           <a href="#" class="tooltip"> <%= image_tag "tooltip.gif" %> <span style="font-size: 12px;"> <br> 
@@ -50,6 +50,7 @@
       <td>
          <div class="bannermenu" style='display: inline;right:10px;'>
            <ul id='menu-bannermenu'>
+             <br><br><br>
              <li class='menu-item current-menu-item'><a href="#" onclick="window.location = '/dashboard'">Dashboard</a></li>
              <li class='menu-item'><a href="#" onclick="window.location = '/analytics'">Analytics</a></li>
              <li class='menu-item'><a href="#" onclick="window.location = '/report'">Reports</a></li>
@@ -59,7 +60,9 @@
     </tr></tbody></table>
   </div>
 </div>
+<br>
 <hr>
+<br>
 
 <%= yield %>
 </div>


### PR DESCRIPTION
Currently the button leading to the Reports page on the upper right corner of the page wraps to the second line. This PRs aims at fixing this problem.
