### PR TITLE
fix off-positioned layout in firefox

### DIFF
--- a/app/assets/stylesheets/analytics.css
+++ b/app/assets/stylesheets/analytics.css
@@ -73,7 +73,7 @@ td.highlight {
 
 div.drops {
     height: 30px;
-    margin-top: 10px;
+    margin-top: 0px;
 }
 
 div.drop label {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,6 +26,7 @@ div.banner {
   float:left;
   font-size: 24px;
   background-color: #fff;
+  height:90px;
 }
 
 div.inner_banner {
@@ -144,7 +145,7 @@ input[type="submit"] {
 
 div.drops {
     height: 60px;
-    margin-top: 10px;
+    margin-top: 0px;
 }
 
 div.drop label {
@@ -472,12 +473,11 @@ body .ui-tooltip {
 
 /* new top menu */
 ul#menu-bannermenu {
-    margin: 0;
-    padding: 0;
     list-style-image: none;
     list-style-type: none;
     font-family: 'PT Sans Narrow', arial, sans-serif;
     float: right;
+    -webkit-margin-before: -4px;
 }
 
 ul#menu-bannermenu li {
@@ -488,7 +488,6 @@ ul#menu-bannermenu li {
 
 div.bannermenu {
     text-align: left;
-    padding-bottom: 10px;
     margin-left: 200px;
 }
 
@@ -561,4 +560,15 @@ div.bannermenu li.current-menu-item a span {
     font-weight: bold;
     color: red;
     margin: 0.5em 0;
+}
+
+.theme {
+	display: inline-block;
+	margin-top: -16px;
+	border-style: inset;
+	border-top-width: 1px;
+	border-bottom-width:0px;
+	border-color: #9A9A9A;
+	height: 0px;
+	width:960px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
 <meta charset="UTF-8">
 <body>
 <div id='content' >
-<div class='page' style='height:100%;'>
+<div class='page' style='height:100%; display:block;'>
 <div class="banner">
   <div style='display:inline;height:90px;width:960px;'>
     <table style='width:960px;'><tbody><tr>
@@ -27,7 +27,7 @@
           <img src="http://cloudfoundry.org/images/logo_org.png" alt="Community Analytics for the Cloud Foundry Foundation." style='height:80px;width:120px;'>
        </a>
       </td>
-      <td style='width:570px;padding-bottom: 30px;'>
+      <td style='width:570px;padding-bottom: 0px;'>
         <span style='font-size: 22px;font-weight:500;line-height:30px;'> Community Analytics: Cloud Foundry Foundation </span>
     <% else %>
       <td style='float:left;padding: 4px 10px;'>
@@ -35,7 +35,7 @@
           <img src="https://d3oypxn00j2a10.cloudfront.net/0.12.6/img/homepage/docker-whale-home-logo-@2x.png?e2946566d408" alt="Community Analytics for the Docker Community." style='height:80px;width:120px;'>
         </a>
       </td>
-      <td style='width:570px;padding-bottom: 30px;'>
+      <td style='width:570px;padding-bottom: 0px;'>
         <span style='font-size: 22px;font-weight:500;line-height:30px;'> Community Analytics: Docker </span>
   <% end %>
         <span>
@@ -50,7 +50,7 @@
       <td>
          <div class="bannermenu" style='display: inline;right:10px;'>
            <ul id='menu-bannermenu'>
-             <br><br><br>
+             <br style='line-height: 42px;'>
              <li class='menu-item current-menu-item'><a href="#" onclick="window.location = '/dashboard'">Dashboard</a></li>
              <li class='menu-item'><a href="#" onclick="window.location = '/analytics'">Analytics</a></li>
              <li class='menu-item'><a href="#" onclick="window.location = '/report'">Reports</a></li>
@@ -60,10 +60,7 @@
     </tr></tbody></table>
   </div>
 </div>
-<br>
-<hr>
-<br>
-
+<hr class='theme'></hr>
 <%= yield %>
 </div>
 <div id="footer_content" class='footer'>


### PR DESCRIPTION
Currently dashboard renders fines in Chrome but the filter buttons, charts and table are rendered to the right of the banner in Firefox.  This PR aims at fixing this problem by moving the content shifted to the right of banner directly under the banner.  This PR further reduced the spaces between the banner, the dividing line and filter buttons so that the charts and tables got push up further to the top of the browser.
