### PR TITLE
fix alignment issues with bottom on chrom browser

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
       </td>
       <td>
          <div class="bannermenu" style='display: inline;right:4px;'>
-           <ul id='menu-bannermenu'>
+           <ul id='menu-bannermenu' style='margin-top: 0px;margin-bottom: -10px;'>
              <br style='line-height: 42px;'>
              <li class='menu-item current-menu-item'><a href="#" onclick="window.location = '/dashboard'">Dashboard</a></li>
              <li class='menu-item'><a href="#" onclick="window.location = '/analytics'">Analytics</a></li>


### PR DESCRIPTION
Buttons on Chrome browser were to high from the beneath separation line.  This PRs aims at fixing this problem.
