### PR TITLE
fixed duplicate IDs for stack and wayne

### DIFF
--- a/config/graf/merge_companies.json
+++ b/config/graf/merge_companies.json
@@ -14,7 +14,7 @@
     },
     {
      "name": "Stark & Wayne",
-     "alias": ["stark and wayne", "stark & wayne"]
+     "alias": ["stark and wayne", "stark & wayne", "https://starkandwayne.com/", "http://starkandwayne.com/"]
     },
     {
      "name": "IBM",


### PR DESCRIPTION
Prior to this PR, the Stark and Wayne account also has "https://starkandwayne.com" as its ID on both the dashboard and the analytics page.  This PR is fix this duplication.
