### PR TITLE
corrected data type in database schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20140619022802) do
 
   create_table "github_load_msgs", force: true do |t|
     t.integer  "github_load_id"
-    t.string   "msg"
+    t.text     "msg"
     t.integer  "log_level"
     t.datetime "log_date"
     t.datetime "created_at"


### PR DESCRIPTION
Prior to this PR, the msg column was wrongly typed to "string", which the underlying mysql database couldn't understand.  This error has surveyed because the it has been corrected by the rake migration process.  This PR aims at fix this defect once for all. 
