### PR TITLE
added Swisscom and functionality for mediating github accounts which onl...

### DIFF
--- a/config/graf/email_to_company.json
+++ b/config/graf/email_to_company.json
@@ -213,6 +213,10 @@
       "alias": ["spotify"]
     },
     {
+      "name": "Swisscom",
+      "alias": ["swisscom.ch"]
+    },
+    {
       "name": "Subuser",
       "alias": ["subuser"]
     },

--- a/config/graf/merge_companies.json
+++ b/config/graf/merge_companies.json
@@ -14,7 +14,7 @@
     },
     {
      "name": "Stark & Wayne",
-     "alias": ["stark and wayne", "stark & wayne", "https://starkandwayne.com/", "http://starkandwayne.com/"]
+     "alias": ["stark and wayne", "stark & wayne", "https://starkandwayne.com", "http://starkandwayne.com"]
     },
     {
      "name": "IBM",
@@ -103,6 +103,10 @@
     {
       "name": "Spotify",
       "alias": ["spotfiy"]
+    },
+    {
+      "name": "Swisscom IT Services Finance",
+      "alias": ["Swisscom IT Services Finance"]
     },
     {
       "name": "Target",

--- a/lib/load_steps/post_fix_users_hidden_identities.rb
+++ b/lib/load_steps/post_fix_users_hidden_identities.rb
@@ -14,7 +14,14 @@ class PostFixUsersWithHiddenIdentity < LoadStep
     Constants.mediation.each do |mapping|
       puts "assigning user #{mapping['login']} to company #{mapping['company']}"
       company = LoadHelpers.create_company_if_not_exist(mapping['company'])
-      User.where(login:  mapping['login']).update_all(company_id: company.id) if mapping['login'].length > 0
+      mapping['users'].each do | user |
+        if user.length == 2
+          puts "updating user #{ user['name'] }"
+          User.where(login:  user['login']).update_all(company_id: company.id, name: user['name']) 
+        else
+          User.where(login:  user['login']).update_all(company_id: company.id) 
+        end
+      end
     end
   end
 

--- a/mediation/cf_mediation.json
+++ b/mediation/cf_mediation.json
@@ -2,35 +2,51 @@
   "community": [
     {
       "company": "Pivotal",
-      "login": [ "jacksoncvm", "amitkgupta", "mstine", "matthewmcnew", "nierajsingh", "dbailey", "cdavisafc", "wilkinsona", "dsabeti", "caseymct", "pjk25", "datianshi"]
+      "users": [ 
+        {"login":"jacksoncvm"}, 
+        {"login": "amitkgupta"}, 
+        {"login":"mstine"}, 
+        {"login": "matthewmcnew"}, 
+        {"login": "nierajsingh"}, 
+        {"login": "dbailey"}, 
+        {"login": "cdavisafc"}, 
+        {"login": "wilkinsona"},
+        {"login": "dsabeti"}, 
+        {"login": "caseymct"}, 
+        {"login": "pjk25"}, 
+        {"login": "datianshi"} ]
     },
     {
       "company": "CityIndex",
-      "login": [ "mrdavidlaing"]
+      "users": [ {"login": "mrdavidlaing"} ]
     },
     {
       "company": "VMware",
-      "login": [ "joeldsa"]
+      "users": [ {"login": "joeldsa"} ]
     },
     {
       "company": "IBM",
-      "login": [ "jgawor"]
+      "users": [ {"login": "jgawor"} ]
     },
     {
       "company": "Web Drive Ltd",
-      "login": [ "aristotelesneto"]
+      "users": [ {"login": "aristotelesneto"} ]
     },
     {
       "company": "Cisco",
-      "login": [ "trastle"]
+      "users": [ {"login": "trastle"} ]
     },
      {
       "company": "Stark & Wayne",
-      "login": [ "longnguyen11288"]
+      "users": [ {"login": "longnguyen11288"} ]
     },
     {
       "company": "CentryLink",
-      "login": [ "scottdensmore"]
-    }   
+      "users": [ {"login": "scottdensmore"} ]
+    },
+    {
+      "company": "Swisscom",
+      "users": [ {"login": "nicregez", "name": "Nicolas Regez"} ]
+    }
   ]
 }

--- a/mediation/docker_mediation.json
+++ b/mediation/docker_mediation.json
@@ -2,115 +2,123 @@
   "community": [
     {
       "company": "Docker, Inc.",
-      "login": [ "mzdaniel", "tiborvass", "ewindisch", "hollietealok"]
+      "users": [ 
+      	{"login": "mzdaniel"}, 
+        {"login": "tiborvass"},
+        {"login": "ewindisch"},
+        {"login": "hollietealok"} ]
     },
     {
       "company": "subuser",
-      "login": [ "timthelion"]
+      "users": [ {"login": "timthelion"} ]
     },
     {
       "company": "soundcloud",
-      "login": [ "bernerdschaefer"]
+      "users": [ {"login": "bernerdschaefer"} ]
+    },
+    {
+      "company": "IBM",
+      "users": [ {"login": "duglin"} ]
     },
     {
       "company": "Imagescape",
-      "login": [ "dustinlacewell"]
+      "users": [ {"login": "dustinlacewell"} ]
     },
     {
       "company": "Canonical Ltd",
-      "login": [ "hamo"]
+      "users": [ {"login": "hamo"} ]
     },
     {
       "company": "Zenoss, Inc",
-      "login": [ "daniel-garcia"]
+      "users": [ {"login": "daniel-garcia"} ]
     },
      {
       "company": "GoodCode",
-      "login": [ "aigeruth"]
+      "users": [ {"login": "aigeruth"} ]
     },
     {
       "company": "Runnable",
-      "login": [ "anandkumarpatel"]
+      "users": [ {"login": "anandkumarpatel"} ]
     },
     {
       "company": "Spotify",
-      "login": [ "danielnorberg"]
+      "users": [ {"login": "danielnorberg"} ]
     },
     {
       "company": "Red Hat",
-      "login": [ "imain"]
+      "users": [ {"login": "imain"} ]
     },
     {
       "company": "Intoximeters",
-      "login": [ "thedude05"]
+      "users": [ {"login": "thedude05"} ]
     },
     {
       "company": "Hybris",
-      "login": [ "maltej"]
+      "users": [ {"login": "maltej"} ]
     },
     {
       "company": "Twitter",
-      "login": [ "financecoding"]
+      "users": [ {"login": "financecoding"} ]
     },
     {
       "company": "Arch Linux ARM",
-      "login": [ "warheadsse"]
+      "users": [ {"login": "warheadsse"}]
     },
     {
       "company": "1uptalent",
-      "login": [ "amuino"]
+      "users": [ {"login": "amuino"} ]
     },
     {
       "company": "Target",
-      "login": [ "mrallen1"]
+      "users": [ {"login": "mrallen1"} ]
     },
     {
       "company": "AcademiaSinicaNLPLab",
-      "login": [ "viirya"]
+      "users": [ {"login": "viirya"} ]
     },
     {
       "company": "Jumpbox",
-      "login": [ "kstaken"]
+      "users": [ {"login": "kstaken"} ]
     },
     {
       "company": "ZoomSystems",
-      "login": [ "fcarriedo"]
+      "users": [ {"login": "fcarriedo"} ]
     },
     {
       "company": "CoreOS",
-      "login": [ "bcwaldon"]
+      "users": [ {"login": "bcwaldon"} ]
     },
     {
       "company": "Amazon",
-      "login": [ "kzys"]
+      "users": [ {"login": "kzys"} ]
     },
     {
       "company": "Rackspace",
-      "login": [ "wking"]
+      "users": [ {"login": "wking"} ]
     },
     {
       "company": "Nauxuat",
-      "login": [ "Sa2ajj"]
+      "users": [ {"login": "Sa2ajj"} ]
     },
     {
       "company": "Zenoss, Inc",
-      "login": [ "daniel-garcia"]
+      "users": [ {"login": "daniel-garcia"} ]
     },
     {
       "company": "Alphagov",
-      "login": [ "pwaller"]
+      "users": [ "{"login": pwaller"} ]
     },
     {
       "company": "Contegix",
-      "login": [ "thedude05"]
+      "users": [ {"login": "thedude05"} ]
     },
     {
       "company": "Redmine",
-      "login": [ "jbbarth"]
+      "users": [ {"login": "jbbarth"} ]
     },
     {
       "company": "Codeclimate",
-      "login": [ "calavera"]
+      "users": [ {"login": "calavera"} ]
     }    
   ]
 }

--- a/mediation/mediation.json
+++ b/mediation/mediation.json
@@ -1,4 +1,5 @@
 {
   "community": [
+    "users": [  {"login": "required", "name": "optional"} ]
   ]
 }


### PR DESCRIPTION
...y have login id but not user names

In the process of adding Swisscom to the list of companies known to contribute to the CloudFoundry community, I came across case that some github accounts had only login ID but lacked the user name.   Sometimes, as we learned more about these accounts, there came a need to add user name to the accounts.  But the current mediation plans can only take gitbhub login ID.  So besides adding the Swisscom to our registry,  this PR also aims at adding the functionality of changing user names via mediation process.  By adding user name to the mediation plan, the PostFixConvertUsersWithoutCompaniesToIndependent step will associate the user name to with the given github login id.  
