### PR TITLE
preserve null values at time of rendering the API data

### DIFF
--- a/lib/analytic_utils.rb
+++ b/lib/analytic_utils.rb
@@ -62,10 +62,10 @@ class AnalyticUtils
     sql_stmt += where_clause_stmt(search_criteria)
     group_by_label_cols = label_columns.map {|column| column[:alias]}
     sql_stmt += "GROUP BY #{group_by_label_cols.join(", ")} "
-    sql_outter_stmt = not_null_select(sql_stmt, group_by_label_cols)
-   
-    sql_outter_stmt += order_by_rollup(label_columns, data_column, rollup_method, order_via_group_bys)
-    return sql_outter_stmt
+
+    sql_stmt += order_by_rollup(label_columns, data_column, rollup_method, order_via_group_bys)
+
+    return sql_stmt
   end
 
   def self.not_null_select(inner_sql, select_columns)


### PR DESCRIPTION
The three data tables on the dashboard page shows aggregations of metrics such as PRs or commits by certain attributes, such as company names and user names.  Unfortunately, there are such cases where company name and user names are missing.  While there is only one company without a name, there were 140 github accounts without user names at one point in time.  The missing user names manifest themselves as null values in our underlying database, mysql, and they seem to interfere with the aggregation.   The 'Contribution by engineers' module on the dashboard bears the direct impact of this problem.  One solution considered was to exclude those github accounts without user names, but that led to a concern of distorting the grand total count of metric and hence the percentage of aggregation.  An alternative approach was to backfill the missing user names with github login ids.  Since the login id is a mandatory entry when creating a github account, this approach eliminates all the problem associated with empty user names and hence makes the mechanism of filtering out empty user names obsolete. This PR is remove the filtering logic.
