### PR TITLE
improve error handling

### DIFF
--- a/lib/load_steps/load_helpers.rb
+++ b/lib/load_steps/load_helpers.rb
@@ -60,8 +60,12 @@ class LoadHelpers
       user_details = lookup_user_details(client, pr_user)
 
       # "Clean" company name, removing initial, capitilzing, etc
-      company_name = merge(user_details[:attrs][:company])
-      company = create_company_if_not_exist(company_name)
+      if user_details 
+        company_name = merge(user_details[:attrs][:company])
+        company = create_company_if_not_exist(company_name)
+      else
+        company = nil
+      end
 
       # TODO, Determine whether always removing middle initial is such a good idea. Searching with initial seems to break github search
 
@@ -85,8 +89,15 @@ class LoadHelpers
   end
 
   def self.lookup_user_details(client, pr_user)
-    api_call_speed_regulator(client)
-    pr_user[:_rels][:self].get.data
+    begin
+      api_call_speed_regulator(client)
+      pr_user[:_rels][:self].get.data
+    rescue Exception => e
+      GithubLoad.log_current_msg("The following error occured wh loading PR user details #{ pr_user } ...", LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.message, LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.backtrace.join("\n"), LogLevel::ERROR)
+      return nil
+    end
   end
 
   def self.github_user(client, user_name)
@@ -95,13 +106,27 @@ class LoadHelpers
   end
 
   def self.github_contributors(client, repo_name)
-    api_call_speed_regulator(client)
-    client.contributors(repo_name);
+    begin
+      api_call_speed_regulator(client)
+      client.contributors(repo_name)
+    rescue Exception => e
+      GithubLoad.log_current_msg("The following error occured wh loading contributors for repo #{ repo_name } ...", LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.message, LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.backtrace.join("\n"), LogLevel::ERROR)
+      return nil
+    end
   end
 
   def self.github_collaborators(client, repo_name)
-    api_call_speed_regulator(client)
-    client.collaborators(repo_name);
+    begin
+      api_call_speed_regulator(client)
+      client.collaborators(repo_name);
+    rescue Exception => e
+      GithubLoad.log_current_msg("The following error occured wh loading collaborators for repo #{ repo_name } ...", LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.message, LogLevel::ERROR)
+      GithubLoad.log_current_msg(e.backtrace.join("\n"), LogLevel::ERROR)
+      return nil
+    end
   end
 
   def self.github_organization_repositories(client, login)

--- a/lib/load_steps/post_fix_users_without_companies.rb
+++ b/lib/load_steps/post_fix_users_without_companies.rb
@@ -28,7 +28,7 @@ class PostFixUsersWithoutCompanies < LoadStep
   
             # Only put in a company if they don't already have one
             if user && (!user.company || user.company == Company.find_by(name: "independent"))
-              GithubLoad.log_current_msg("#{user} is in #{company}", LogLevel::INFO)
+              GithubLoad.log_current_msg("#{user} without clear company info is assigned to  #{company} as per org_to_company mapping", LogLevel::INFO)
               user.company = company
               user.save
             end


### PR DESCRIPTION
Currently the processing of contributors and collaborators can be short-circuited when there is error in the retrieving user details.  This PR aims at isolating the failure to just the problematic user so the rest of the users will still have a chance to be processed.  Also improve error message for processing users who have no company info in their accounts.