### PR TITLE
fixed problem of sticky user filter settings

### DIFF
--- a/app/assets/javascripts/search.js.erb
+++ b/app/assets/javascripts/search.js.erb
@@ -9,7 +9,7 @@ DATE_PICKER_OPTIONS = {
 //
 function loadFiltersFromLocalStorage() {
   // Load and parse local storage
-  var values = window.localStorage.getItem('vals');
+  var values = window.sessionStorage.getItem('vals');
   values = $.parseJSON(values);
   for (v in values){
     $("#" + toUnderscore(v) + "_filter").val(values[v]);
@@ -18,8 +18,8 @@ function loadFiltersFromLocalStorage() {
 
 function storeFiltersToLocalStorage() {
   // TODO?: This will not save state if commits is selected
-  values = createSearchCriteriaJSON();
-  localStorage.setItem('vals', JSON.stringify(values));
+  var values = createSearchCriteriaJSON();
+  sessionStorage.setItem('vals', JSON.stringify(values));
 }
 
 //

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -12,6 +12,7 @@ class AnalyticsController < ApplicationController
     @user_logins = User.order(:login).select('DISTINCT(login)').where("login <> ''")
     @user_names = User.order(:name).select('DISTINCT(name)').where("name <> '' and name not like '___'")
     @last_updated = GithubLoad.last
+    @load_completion_time = GithubLoad.last_completed["load_complete_time"]
   end
 
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,6 +9,7 @@ class DashboardController < ApplicationController
     @user_logins = User.order(:login).select('DISTINCT(login)').where("login <> ''")
     @user_names = User.order(:name).select('DISTINCT(name)').where("name <> '' and name not like '___'")
     @last_updated = GithubLoad.last
+    @load_completion_time = GithubLoad.last_completed["load_complete_time"]
   end
 
 end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -15,6 +15,7 @@ class ReportController < ApplicationController
     @user_logins = User.order(:login).select('DISTINCT(login)').where("login <> ''")
     @user_names = User.order(:name).select('DISTINCT(name)').where("name <> '' and name not like '___'")
     @last_updated = GithubLoad.last
+    @load_completion_time = GithubLoad.last_completed["load_complete_time"]
   end
   
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,20 @@
 </head>
 <meta charset="UTF-8">
 <body>
+  <script type="text/javascript">
+    //
+    // Initial Page Load Activities
+    //
+    var last_load_time = window.localStorage.getItem('data_load_time');
+    var current_load_time = '<%=@load_completion_time %>';
+
+    if ( last_load_time == null) {
+      window.localStorage.setItem('data_load_time', current_load_time )
+    } else if ( last_load_time < current_load_time) {
+      window.sessionStorage.removeItem('vals');
+      window.localStorage.setItem('data_load_time', current_load_time )
+    }
+  </script>
 <div id='content' >
 <div class='page' style='height:100%; display:block;'>
 <div class="banner">


### PR DESCRIPTION
Prior to this PR, GRAF has a problem of remembering user setting on filters even after user close the browser or browser tab.  This behavior is often time counter intuitive to many users.  In general, people tend to expect seeing the default settings upon launch of a new tab or new instance of browser.  As a result, the numbers shown can be drastically different from those rendered with default settings.  Some user described this behavior a caching problem, which is more severe in FireFox than Chrome. 

The current implement relies on a feature in HTML 5 known as "localStorage" to store the users' filter criteria so that the same filter criteria can be automatically applied when users switch from one view to another.  For example, when user picks 2015 on the year filter of the analytic page and then switches over to the reports page, the same filter will be at work on the reports page.  This has been a feature of GRAF.  

It is rather unfortunate that the localStorage mechanism actually persists its contents on to disk.  So when user launches a new instance of the same type of browser, this memory is brought up from disk memory and replied to the new instance.  That is the reason behind the stickiness of user setting.  The only way to erase the persisted memory is clear all user data and history from the beginning of time.  Obviously, this is not a practical for majority of general users.

This PR aim at fixing this problem with another persistent mechanism called sessionStorage, which resides only in RAM memory.  Upon closing of browser tab, this memory will be erased.  Also each tab has its independent copy of memory so the filter setting on one tab doesn't interfere with a GRAF instance running on another tab.

However switching to sessionStorage alone still leaves one scenario not yet tackled - user keeps a browser tab running but unattended for days while GRAF undergone numerous updates.  When user reaches to this old tab instance, the old filter criteria continue to be at work and a click on the Refresh browser button doesn't erase the sessionStorage content.  So the user will see the same problem which led to this PR at the first place.  To address this problem, the code is modified to persist the last data load time onto localStorage's memory; GRAF always renders a page with the last data load time info which will be compared with the time kept in localStorage.  When a new data load is detected, the new logic will first empty the filter criteria persisted in the sessionStorage.