### PR TITLE
changed dashboard default filter to show merged PRs

### DIFF
--- a/app/views/shared/_search_criteria.html.erb
+++ b/app/views/shared/_search_criteria.html.erb
@@ -124,7 +124,7 @@
         <label>State</label>
         <select id="state_filter" style='width:140px;' class="multiselect" multiple="multiple">
           <option value="open">Open</option>
-          <option value="merged">Merged</option>
+          <option value="merged" selected >Merged</option>
           <option value="closed">Closed (Not Merged)</option>
         </select>
       </div>


### PR DESCRIPTION
Currently the dashboard shows PRs of all states by default.  However, merged PRs are usually better metrics in measure contributions to community.  This PR aims at changing the default filters of dashboard to show merged PRs.